### PR TITLE
Fixed UICollectionViewFlowLayout warning

### DIFF
--- a/RGCardViewLayout.m
+++ b/RGCardViewLayout.m
@@ -18,8 +18,8 @@
 
 - (void)prepareLayout
 {
-    [super prepareLayout];
     [self setupLayout];
+    [super prepareLayout];
 }
 
 


### PR DESCRIPTION
Calling _prepareLayout_ before setting the collectionViewFlow's item size (in _setupLayout_) results in a warning
"the item width must be less than the width of the UICollectionView minus the section insets left and right values.".

The solution is to adjust the item width before it's first layout instance (_prepareLayout_).
