### PR TITLE
fix log warning

### DIFF
--- a/RGCardViewLayout.m
+++ b/RGCardViewLayout.m
@@ -34,7 +34,7 @@
 
 - (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForItemAtIndexPath:indexPath];
+    UICollectionViewLayoutAttributes *attributes = [[super layoutAttributesForItemAtIndexPath:indexPath] copy];
     [self applyTransformToLayoutAttributes:attributes];
     
     return attributes;
@@ -47,7 +47,8 @@
 
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
 {
-    NSArray *attributes = [super layoutAttributesForElementsInRect:rect];
+    NSArray *attributesSuper = [super layoutAttributesForElementsInRect:rect];
+    NSArray *attributes = [[NSArray alloc] initWithArray:attributesSuper copyItems:YES];
     
     NSArray *cellIndices = [self.collectionView indexPathsForVisibleItems];
     if(cellIndices.count == 0 )


### PR DESCRIPTION
fix log warning “This is likely occurring because the flow layout
subclass RGCardViewLayout is modifying attributes returned by
UICollectionViewFlowLayout without copying them”
